### PR TITLE
added extended search as an iframe to the tab

### DIFF
--- a/fetlife-age-sex-location-search.user.js
+++ b/fetlife-age-sex-location-search.user.js
@@ -5,7 +5,7 @@
  */
 // ==UserScript==
 // @name           FetLife ASL Search (Extened Edition)
-// @version        0.4.6
+// @version        0.4.7
 // @namespace      http://maybemaimed.com/playground/fetlife-aslsearch/
 // @updateURL      https://github.com/meitar/fetlife-aslsearch/raw/master/fetlife-age-sex-location-search.user.js
 // @description    Allows you to search for FetLife profiles based on age, sex, location, and role.
@@ -666,9 +666,9 @@ FL_ASL.attachSearchForm = function () {
     container.appendChild(FL_ASL.createSearchTab('fetlife_asl_search_about', html_string));
 
     // Extended search tab
-    html_string = '<div id="fetlife_asl_search_extended_wrapper">';
-    html_string += '<h2><a href="' + FL_ASL.CONFIG.gasapp_url.split('?')[0] + '" target="_blank">Open Extended A/S/L Search</a></h2>';
-    html_string += '</div><!-- #fetlife_asl_search_extended_wrapper -->';
+    html_string = '<br><div id="fetlife_asl_search_extended_wrapper">';
+    html_string += '<iframe src="' + FL_ASL.CONFIG.gasapp_url.split('?')[0] + '" width="100%" height="500px"><h2><a href="' + FL_ASL.CONFIG.gasapp_url.split('?')[0] + '" target="_blank">Open Extended A/S/L Search</a></h2></iframe>';
+    html_string += '</div><!-- # -->';
     var newdiv = container.appendChild(FL_ASL.createSearchTab('fetlife_asl_search_extended', html_string));
 
     // Main ASL search option interface

--- a/server/Code.gs
+++ b/server/Code.gs
@@ -16,6 +16,7 @@ function doGet (e) {
       output = t.evaluate().setSandboxMode(HtmlService.SandboxMode.IFRAME);
       break;
   }
+  output.setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL);
   return output;
 }
 


### PR DESCRIPTION
1. Enabling Iframe use in g-script code
2. adding iframe to extended search tab.
3. moving link to iframe-not-supported
4. Changing version to 0.4.9
DNM before version 0.4.8, or change version number
5. cleaned and squashed.